### PR TITLE
Fix factory pool, _children -> children

### DIFF
--- a/cobald/composite/factory.py
+++ b/cobald/composite/factory.py
@@ -43,14 +43,14 @@ class FactoryPool(CompositePool):
     @property
     def utilisation(self):
         try:
-            return sum(child.utilisation for child in self._children) / len(self._children)
+            return sum(child.utilisation for child in self.children) / len(self.children)
         except ZeroDivisionError:
             return 1.
 
     @property
     def allocation(self):
         try:
-            return sum(child.allocation for child in self._children) / len(self._children)
+            return sum(child.allocation for child in self.children) / len(self.children)
         except ZeroDivisionError:
             return 1.
 


### PR DESCRIPTION
Dear Eileen, Max,

this commit fixes a problem with the factory pool. `utilisation` and `allocation` used the deprecated `self.__children` attribute.

Could you review and merge, please?

Thanks,
Manuel