### PR TITLE
fix update interval for factory pool

### DIFF
--- a/cobald/composite/factory.py
+++ b/cobald/composite/factory.py
@@ -74,7 +74,7 @@ class FactoryPool(CompositePool):
 
     async def run(self):
         while True:
-            await trio.sleep_until(self.interval)
+            await trio.sleep(self.interval)
             # freeze target demand in case another thread updates us
             supply, demand = self.supply, self.demand
             if supply > demand:


### PR DESCRIPTION
`trio.sleep_until` has as argument an absolute time. `trio.sleep` has as argument the number of seconds to wait.