### PR TITLE
Distribute demand equaly over pools, if total_supply is zero

### DIFF
--- a/cobald/composite/weighted.py
+++ b/cobald/composite/weighted.py
@@ -15,8 +15,12 @@ class WeightedComposite(CompositePool):
     def demand(self, value):
         self._demand = value
         total_supply = self.supply
+        child_count = len(self.children)
         for pool in self.children:
-            pool.demand = value * pool.supply / total_supply
+            try:
+                pool.demand = value * pool.supply / total_supply
+            except ZeroDivisionError:
+                pool.demand = value / child_count
 
     @property
     def supply(self):


### PR DESCRIPTION
Hi @maxfischer2781,

if there is no supply in the pools belonging to a WeightedComposite. Set demand will throw a `ZeroDivision` exception. I would suggest to mimic the UniformComposite behaviour on pools with no supply, for example newly started once.

Cheers,
Manuel